### PR TITLE
Remove incorrect addressof from InstallConfigurationTable sample

### DIFF
--- a/5_uefi_services/52_services_that_uefi_drivers_rarely_use/5210_installconfigurationtable.md
+++ b/5_uefi_services/52_services_that_uefi_drivers_rarely_use/5210_installconfigurationtable.md
@@ -118,7 +118,7 @@ UndiConfigTable = (UNDI_CONFIG_TABLE *)AllocateRuntimeZeroPool (
 //
 Status = gBS->InstallConfigurationTable (
                 &gEfiNetworkInterfaceIdentifierProtocolGuid_31,
-                &UndiConfigTable
+                UndiConfigTable
                 );
 if (EFI_ERROR (Status)) {
   return Status;


### PR DESCRIPTION
InstallConfigurationTable takes a pointer to a GUID and a pointer to a buffer.

The sample passes the pointer to the pointer, which means the sample is wrong.

When developers use this sample as the starting point for their code, they will have a bug that is very tricky to see in their code and tricky to diagnose.

This issue wasted several hours of my time today.

This fixes issue #5 

Contributed-under: TianoCore Contribution Agreement 1.1
Signed-off-by: Doug Cook <dcook@microsoft.com>